### PR TITLE
Fix zoom anchoring when zooming and panning

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -179,18 +179,16 @@ function handleWheel(e) {
   const rect = canvas.getBoundingClientRect();
   const mouseX = e.clientX - rect.left;
   const mouseY = e.clientY - rect.top;
+  const canvasX = mouseX / scale;
+  const canvasY = mouseY / scale;
   
   // Zoom factor
   const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
   const newScale = Math.min(Math.max(0.5, scale * zoomFactor), 5);
-  
-  // Calculate the point in canvas space before zoom
-  const canvasX = (mouseX - translateX) / scale;
-  const canvasY = (mouseY - translateY) / scale;
-  
+
   // Adjust translation to keep the point under cursor fixed
-  translateX = mouseX - canvasX * newScale;
-  translateY = mouseY - canvasY * newScale;
+  translateX += canvasX * (scale - newScale);
+  translateY += canvasY * (scale - newScale);
   
   scale = newScale;
   applyTransform();
@@ -227,14 +225,12 @@ function handleTouchMove(e) {
       const rect = canvas.getBoundingClientRect();
       const localX = centerX - rect.left;
       const localY = centerY - rect.top;
-      
-      // Calculate the point in canvas space before zoom
-      const canvasX = (localX - translateX) / scale;
-      const canvasY = (localY - translateY) / scale;
+      const canvasX = localX / scale;
+      const canvasY = localY / scale;
       
       // Adjust translation to keep the point under pinch center fixed
-      translateX = localX - canvasX * newScale;
-      translateY = localY - canvasY * newScale;
+      translateX += canvasX * (scale - newScale);
+      translateY += canvasY * (scale - newScale);
       
       scale = newScale;
       lastTouchDistance = currentDistance;


### PR DESCRIPTION
## Summary
- fix zoom anchor calculations for wheel and pinch gestures so the focus point stays under the cursor/gesture
- maintain consistent translation updates after panning to avoid jumps when zooming

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d13e3798832f9164f6e2cafbbdc7)