### PR TITLE
Fix drawing outside template background

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -8,6 +8,7 @@ const modeBtn = document.getElementById("modeBtn");
 
 let drawing = false;
 let eraseMode = false;
+let lastPos = null;
 
 // stacks for undo/redo
 const undoStack = [];
@@ -176,8 +177,13 @@ function draw(e) {
 
   // Check if trying to draw on light blue background
   if (isLightBlueBackground(pos.x, pos.y)) {
-    // Don't draw on the background, but update lastPos to avoid jumps
-    lastPos = pos;
+    // Don't draw on the background; reset the path so returning doesn't create a bridge
+    if (eraseMode) {
+      lastPos = pos;
+    } else {
+      lastPos = null;
+      ctx.beginPath();
+    }
     return;
   }
 
@@ -209,6 +215,14 @@ function draw(e) {
 
     lastPos = pos;
   } else {
+    if (!lastPos) {
+      ctx.beginPath();
+      ctx.moveTo(pos.x, pos.y);
+      lastPos = pos;
+      e.preventDefault();
+      return;
+    }
+
     ctx.lineWidth = size;
     ctx.lineCap = "round";
     ctx.strokeStyle = "black";


### PR DESCRIPTION
## Summary
- reset drawing path when cursor leaves the template background to avoid lines across the light-blue area
- initialize drawing position state to keep stroke handling predictable when re-entering the template

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694402f492d4832f8e2c1aedcebc9698)